### PR TITLE
fix: quicktype as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mime-types": "^2.1.35",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
+    "quicktype": "^23.0.37",
     "standard-version": "^9.3.0",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
@@ -70,7 +71,6 @@
     "@types/mime-types": "^2.1.1",
     "copyfiles": "^2.4.1",
     "epsg-index": "^1.3.0",
-    "quicktype": "^23.0.37",
     "ts-morph": "^18.0.0"
   }
 }


### PR DESCRIPTION
move quicktype to dev dependency