### PR TITLE
chore: move Transparency from raster-shared

### DIFF
--- a/src/enums/common/metadata/transparency.ts
+++ b/src/enums/common/metadata/transparency.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export const Transparency = {
+  OPAQUE: 'OPAQUE',
+  TRANSPARENT: 'TRANSPARENT',
+} as const;
+
+export type Transparency = (typeof Transparency)[keyof typeof Transparency];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './enums/common/artifact';
 export * from './enums/common/metadata/productType';
 export * from './enums/common/metadata/recordStatus';
 export * from './enums/common/metadata/recordType';
+export * from './enums/common/metadata/transparency';
 export * from './enums/geo/epsg';
 export * from './helpers/mime';
 export * from './interfaces/common/metadata';


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |


Further  information:
Move Transparency enum to types package

The Transparency enum, previously located in raster-shared, is  also used by 
the app team. To avoid duplication and maintain a single source of truth, moved 
this enum to the @map-colonies/types package where it can be shared across both teams.

Changes:
- Moved Transparency enum from raster-shared to types package
- Updated imports in affected files
